### PR TITLE
zephyr: targets: update flash driver names to use Zephyr CONFIGs

### DIFF
--- a/boot/zephyr/targets/96b_carbon.h
+++ b/boot/zephyr/targets/96b_carbon.h
@@ -19,7 +19,7 @@
  * @brief Bootloader device specific configuration.
  */
 
-#define FLASH_DRIVER_NAME		"STM32F4_FLASH"
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_STM32_DEV_NAME
 #define FLASH_ALIGN			1
 #define FLASH_AREA_IMAGE_0_OFFSET	0x20000
 #define FLASH_AREA_IMAGE_0_SIZE		0x20000

--- a/boot/zephyr/targets/96b_nitrogen.h
+++ b/boot/zephyr/targets/96b_nitrogen.h
@@ -19,7 +19,7 @@
  * @brief Bootloader device specific configuration.
  */
 
-#define FLASH_DRIVER_NAME		"NRF5_FLASH"
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_NRF5_DEV_NAME
 #define FLASH_ALIGN			4
 #define FLASH_AREA_IMAGE_0_OFFSET	0x08000
 #define FLASH_AREA_IMAGE_0_SIZE		0x3A000

--- a/boot/zephyr/targets/frdm_k64f.h
+++ b/boot/zephyr/targets/frdm_k64f.h
@@ -19,7 +19,7 @@
  * @brief Bootloader device specific configuration.
  */
 
-#define FLASH_DRIVER_NAME		"MCUX_FLASH"
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_MCUX_DEV_NAME
 #define FLASH_ALIGN			8
 #define FLASH_AREA_IMAGE_0_OFFSET	0x20000
 #define FLASH_AREA_IMAGE_0_SIZE		0x20000

--- a/boot/zephyr/targets/nucleo_f401re.h
+++ b/boot/zephyr/targets/nucleo_f401re.h
@@ -19,7 +19,7 @@
  * @brief Bootloader device specific configuration.
  */
 
-#define FLASH_DRIVER_NAME		"STM32F4_FLASH"
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_STM32_DEV_NAME
 #define FLASH_ALIGN			1
 #define FLASH_AREA_IMAGE_0_OFFSET	0x20000
 #define FLASH_AREA_IMAGE_0_SIZE		0x20000


### PR DESCRIPTION
Let's stay in-sync automatically with Zephyr master by referring
to CONFIGs for the flash device names.

Signed-off-by: Michael Scott <michael.scott@linaro.org>